### PR TITLE
Cleanup harvest sources (command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ This command will look for private datasets that have the `scheduled`-field set 
 paster --plugin=ckanext-ogdchcommands ogdch publish_scheduled_datasets [--dryrun] -c /var/www/ckan/development.ini
 ```
 
+## Command to clear stale harvest sources.
+This commands clears all datasets, jobs and objects related to a harvest source 
+that was not active for a given amount of days (default 30 days).
+The command is supposed to be used in a cron job and to check all harvest sources.
+
+```bash
+paster --plugin=ckanext-ogdchcommands ogdch clear_stale_harvestsources [--keep_harvestsource_days={n}}] -c /var/www/ckan/development.ini
+```
+
 ## Installation
 
 To install ckanext-ogdchcommands:

--- a/ckanext/ogdchcommands/commands.py
+++ b/ckanext/ogdchcommands/commands.py
@@ -67,7 +67,7 @@ class OgdchCommands(ckan.lib.cli.CkanCommand):
         #   that deletes all datasets, jobs and objects, but keeps the source itself
         # - the default timeframe to keep harvested datasets is 30 days
         paster ogdch clear_stale_harvestsources
-        [{source_id}] [--keep_harvestsource_days={n}]
+        [--keep_harvestsource_days={n}]
 
     '''
     summary = __doc__.split('\n')[0]

--- a/ckanext/ogdchcommands/logic.py
+++ b/ckanext/ogdchcommands/logic.py
@@ -4,6 +4,7 @@ from ckan.logic import NotFound, ValidationError
 import ckan.plugins.toolkit as tk
 from ckan import model
 from ckanext.harvest.model import HarvestSource, HarvestJob, HarvestObject
+import datetime
 
 import logging
 log = logging.getLogger(__name__)
@@ -191,3 +192,52 @@ def cleanup_package_extra(context, data_dict):
         "count_deleted": count,
         "dryrun": dryrun,
     }
+
+
+def ogdch_cleanup_harvestsource(context, data_dict):
+    """
+    cleaning up jobs for all harvest sources
+    """
+
+    # get the last day to keep harvested datasets
+    timeframe_to_keep_harvested_datasets = \
+        data_dict.get('timeframe_to_keep_harvested_datasets')
+    last_day_to_keep_harvested_ds = \
+        datetime.datetime.now() \
+        - datetime.timedelta(timeframe_to_keep_harvested_datasets)
+
+    # gets all active harvest sources
+    harvest_sources = tk.get_action('harvest_source_list')(context, data_dict)
+    count_cleared_harvestsource = 0
+    if len(harvest_sources) != 0:
+        print('Cleaning up harvester objects for all harvest sources')
+
+    for source in harvest_sources:
+        source_dict = tk.get_action('harvest_source_show')(context, {
+            'id': source['id']
+        })
+        # check if there are any harvest jobs
+        if not source_dict['status']['last_job']:
+            log.info('No jobs yet for this harvest source id={}'.format(
+                source['id']))
+        else:
+            last_job_creation_time = \
+                source_dict['status']['last_job']['created']
+            last_job_creation_time_obj = datetime.datetime.strptime(
+                last_job_creation_time, "%Y-%m-%d %H:%M:%S.%f")
+            last_job_age = (
+                    datetime.datetime.now() - last_job_creation_time_obj).days
+            last_job_status = source_dict['status']['last_job']['status']
+            log.info('The latest job of the harvester id={} is {} days old'
+                     .format(source['id'], last_job_age))
+
+            if (last_job_creation_time_obj < last_day_to_keep_harvested_ds
+                    and last_job_status == "Finished"):
+                count_cleared_harvestsource += 1
+                tk.get_action("harvest_source_clear")(context,
+                                                      {"id": source['id']})
+
+    return {
+            "count_cleared_harvestsource": count_cleared_harvestsource,
+    }
+

--- a/ckanext/ogdchcommands/logic.py
+++ b/ckanext/ogdchcommands/logic.py
@@ -240,4 +240,3 @@ def ogdch_cleanup_harvestsource(context, data_dict):
     return {
             "count_cleared_harvestsource": count_cleared_harvestsource,
     }
-

--- a/ckanext/ogdchcommands/plugin.py
+++ b/ckanext/ogdchcommands/plugin.py
@@ -28,4 +28,5 @@ class OgdchCommandsPlugin(plugins.SingletonPlugin):
             'ogdch_cleanup_harvestjobs': l.ogdch_cleanup_harvestjobs,
             'ogdch_cleanup_resources': l.ogdch_cleanup_resources,
             'cleanup_package_extra': l.cleanup_package_extra,
+            'ogdch_cleanup_harvestsource': l.ogdch_cleanup_harvestsource,
         }


### PR DESCRIPTION
To use the cleanup_harvestsources command in the terminal:
```
 docker-compose exec ckan /usr/local/bin/ckan-paster --plugin=ckanext-ogdchcommands ogdch clear_stale_harvestsources --keep_harvestsource_days=30 -c /etc/ckan/production.ini
```

An example output looks like:
```
User is authorized to perform this action
Cleaning up harvester objects for all harvest sources
2022-01-17 09:25:03,388 INFO  [ckanext.ogdchcommands.logic] ogdch_cleanup_harvestsource 303 The latest job of the harvester id=da73adbb-ed07-4f6a-bd8a-a1ac96b28e6c is 0 days old
2022-01-17 09:25:03,545 DEBUG [ckanext.harvest.logic.action.update] harvest_source_reindex 936 Updating search index for harvest source: zh-kt-gemeindeamt-dcat-harvester
2022-01-17 09:25:03,694 INFO  [ckanext.ogdchcommands.logic] ogdch_cleanup_harvestsource 303 The latest job of the harvester id=113ecdc2-134c-4068-b4af-4cd1e9a44920 is 0 days old
2022-01-17 09:25:03,794 DEBUG [ckanext.harvest.logic.action.update] harvest_source_reindex 936 Updating search index for harvest source: zh-kt-volksschulamt-dcat-harvester
2022-01-17 09:25:03,944 INFO  [ckanext.ogdchcommands.logic] ogdch_cleanup_harvestsource 295 No jobs yet for this harvest source id=c82a15ce-01e2-4989-9ab7-6a0cf47209ba
2 harvest sources were cleared
```