### PR TITLE
feat: add api route in odgch_admin to search for recent activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,16 @@ checks whether there are any unindexed packages in CKAN
 reindexes Solr. You can use it with these arguments: `package_id=<name of the dataset>` and `only_missing=true`
 In the later case only datasets missing in the index will get reindexed
 
-- `/api/3/action/ogdch_check_field?field=<name of the field>>`
+- `/api/3/action/ogdch_check_field?field=<name of the field>`
 
 This checks the database and looks for the given fields in there: the field values will be reported back together
 with the dataset name.
+
+- `/api/3/action/ogdch_latest_dataset_activities`
+
+shows the latests activities on datasets with username, datasetname and a message if available.
+(The user `harvest-notification` adds during harvesting messages about the change that occured on a 
+dataset to the activity that it creates in case of a change on the dataset.)
 
 ## Installation
 

--- a/ckanext/ogdchcommands/admin_logic.py
+++ b/ckanext/ogdchcommands/admin_logic.py
@@ -167,7 +167,7 @@ def _check_and_map_activity_item(item):
                                                 {'id': object_id})
         if package.get('type') != 'dataset':
             return False
-        if item.get('data') and data.get('message'):
+        if data and data.get('message'):
             activity['message'] = data['message']
         activity['package'] = package.get('name')
     except NotFound:

--- a/ckanext/ogdchcommands/admin_logic.py
+++ b/ckanext/ogdchcommands/admin_logic.py
@@ -125,9 +125,9 @@ def _search_for_datasets(context):
 
 
 @side_effect_free
-def ogdch_activity_search(context, data_dict):
+def ogdch_latest_dataset_activities(context, data_dict):
     '''
-    Show recent activities
+    Show recent activities for datasets
     '''
     user = tk.get_action('get_site_user')({'ignore_auth': True}, {})
     context.update({'user': user['name']})

--- a/ckanext/ogdchcommands/admin_logic.py
+++ b/ckanext/ogdchcommands/admin_logic.py
@@ -132,10 +132,13 @@ def ogdch_activity_search(context, data_dict):
     user = tk.get_action('get_site_user')({'ignore_auth': True}, {})
     context.update({'user': user['name']})
 
-    result = tk.get_action('recently_changed_packages_activity_list')(context, data_dict)
+    result = tk.get_action('recently_changed_packages_activity_list')(
+        context,
+        data_dict,
+    )
     activities = []
     for item in result:
-        mapped_activity =  _check_and_map_activity_item(item)
+        mapped_activity = _check_and_map_activity_item(item)
         if mapped_activity:
             activities.append(mapped_activity)
     if activities:
@@ -149,7 +152,8 @@ def _check_and_map_activity_item(item):
     user_id = item.get('user_id')
     object_id = item.get('object_id')
     data = item.get('data')
-    activity_relates_to_a_package = activity_type and 'package' in activity_type
+    activity_relates_to_a_package = \
+        activity_type and 'package' in activity_type
     if not activity_relates_to_a_package:
         return False
     activity = {}

--- a/ckanext/ogdchcommands/plugin.py
+++ b/ckanext/ogdchcommands/plugin.py
@@ -49,5 +49,5 @@ class OgdchAdminPlugin(plugins.SingletonPlugin):
             'ogdch_reindex': admin.ogdch_reindex,
             'ogdch_check_indexing': admin.ogdch_check_indexing,
             'ogdch_check_field': admin.ogdch_check_field,
-            'ogdch_activity_search': admin.ogdch_activity_search,
+            'ogdch_latest_dataset_activities': admin.ogdch_latest_dataset_activities, # noqa
         }

--- a/ckanext/ogdchcommands/plugin.py
+++ b/ckanext/ogdchcommands/plugin.py
@@ -49,4 +49,5 @@ class OgdchAdminPlugin(plugins.SingletonPlugin):
             'ogdch_reindex': admin.ogdch_reindex,
             'ogdch_check_indexing': admin.ogdch_check_indexing,
             'ogdch_check_field': admin.ogdch_check_field,
+            'ogdch_activity_search': admin.ogdch_activity_search,
         }


### PR DESCRIPTION
- only activities that relate to packages are returned

- user_id and object_id are transformed into username and dataset name