### PR TITLE
feat: delete orphaned filestore objects with resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ paster --plugin=ckanext-ogdchcommands ogdch cleanup_datastore -c /var/www/ckan/d
 When datasets are harvested, we try to reuse the existing resources, but not all of them are 
 reused. Some old resources remain with the state 'deleted'. These orphaned resources can be
 deleted with this command. It is meant to be run regularly by a cronjob. 
+It will also deleted all files from the filestore that are associated with the orphaned resources.
 It also comes with a dryrun option.
 
 ```bash

--- a/ckanext/ogdchcommands/commands.py
+++ b/ckanext/ogdchcommands/commands.py
@@ -9,7 +9,9 @@ from datetime import datetime
 
 msg_resource_cleanup_dryrun = """Resources cleanup:
 ==================
-There are {} resources in status 'deleted'.
+There are {0} resources in status 'deleted'.
+There are {1} filestore-entries associated with those resources that can be deleted.
+{2}
 If you want to delete them, run this command
 again without the option --dryrun!"""
 
@@ -44,9 +46,6 @@ class OgdchCommands(ckan.lib.cli.CkanCommand):
         # - also cleans their dependencies in resource_view and resource_revision
         # - the command can be performed with a dryrun option where the
         #   database will remain unchanged
-        paster ogdch cleanup_resources [--delete_filestore_files]
-        # - option delete_filestore_files will also delete associated data from
-        #   the filestore after deleting the orphaned resources
 
 
         # Cleanup package_extras
@@ -97,11 +96,6 @@ class OgdchCommands(ckan.lib.cli.CkanCommand):
             default=30,
             help='Initial timeframe to keep harvested datasets, '
                  'jobs and objects.')
-        self.parser.add_option(
-            '--delete_filestore_files', action="store_true", dest='delete_filestore_files',
-            default=False,
-            help='Option to delete orphaned filestore-files as well when '
-                 'deleting orphaned resources when running cleanup_resources.')
 
     def command(self):
         # load pylons config
@@ -292,14 +286,13 @@ class OgdchCommands(ckan.lib.cli.CkanCommand):
             context,
             {
                 'dryrun': self.options.dryrun,
-                'delete_filestore_files': self.options.delete_filestore_files,
             })
         if self.options.dryrun:
             print(msg_resource_cleanup_dryrun
-                  .format(result.get('count_deleted')))
+                  .format(result.get('count_deleted'), result.get('count_filestores'), result.get('filepaths')))
         else:
             print(msg_resource_cleanup
-                  .format(result.get('count_deleted')))
+                  .format(result.get('count_deleted', result.get('count_filestores'), result.get('filepaths'))))
 
     def cleanup_extras(self, key=None):
         """

--- a/ckanext/ogdchcommands/commands.py
+++ b/ckanext/ogdchcommands/commands.py
@@ -39,9 +39,15 @@ class OgdchCommands(ckan.lib.cli.CkanCommand):
         paster ogdch cleanup_datastore
 
         # Cleanup resources
-        paster ogdch cleanup_resources
+        paster ogdch cleanup_resources [--dryrun]
         # - delete resources that have the state 'deleted'
         # - also cleans their dependencies in resource_view and resource_revision
+        # - the command can be performed with a dryrun option where the
+        #   database will remain unchanged
+        paster ogdch cleanup_resources [--delete_filestore_files]
+        # - option delete_filestore_files will also delete associated data from
+        #   the filestore after deleting the orphaned resources
+
 
         # Cleanup package_extras
         paster ogdch cleanup_extras {key}  [--dryrun]
@@ -91,6 +97,11 @@ class OgdchCommands(ckan.lib.cli.CkanCommand):
             default=30,
             help='Initial timeframe to keep harvested datasets, '
                  'jobs and objects.')
+        self.parser.add_option(
+            '--delete_filestore_files', action="store_true", dest='delete_filestore_files',
+            default=False,
+            help='Option to delete orphaned filestore-files as well when '
+                 'deleting orphaned resources when running cleanup_resources.')
 
     def command(self):
         # load pylons config
@@ -279,7 +290,10 @@ class OgdchCommands(ckan.lib.cli.CkanCommand):
             sys.exit(1)
         result = logic.get_action('ogdch_cleanup_resources')(
             context,
-            {'dryrun': self.options.dryrun})
+            {
+                'dryrun': self.options.dryrun,
+                'delete_filestore_files': self.options.delete_filestore_files,
+            })
         if self.options.dryrun:
             print(msg_resource_cleanup_dryrun
                   .format(result.get('count_deleted')))

--- a/ckanext/ogdchcommands/logic.py
+++ b/ckanext/ogdchcommands/logic.py
@@ -132,18 +132,6 @@ def ogdch_cleanup_harvestjobs(context, data_dict):
     return {'sources': sources_to_cleanup,
             'cleanup': cleanup_result}
 
-def get_directory(id):
-        if storage_path is None:
-            raise TypeError("storage_path is not defined")
-
-        real_storage = os.path.realpath(storage_path)
-        directory = os.path.join(real_storage, id[0:3], id[3:6])
-        if directory != os.path.realpath(directory):
-            raise logic.ValidationError({
-                'upload': ['Invalid storage directory']
-            })
-        return directory
-
 def get_path(id):
         directory = get_directory(id)
         filepath = os.path.join(directory, id[6:])
@@ -169,6 +157,9 @@ def ogdch_cleanup_resources(context, data_dict):
     """
     cleans up the database from resources that have been deleted
     """
+    # setup
+
+
     dryrun = data_dict.get('dryrun')
     delete_filestore_files = data_dict.get('delete_filestore_files')
     tk.check_access('resource_delete', context, data_dict)

--- a/ckanext/ogdchcommands/logic.py
+++ b/ckanext/ogdchcommands/logic.py
@@ -188,7 +188,7 @@ def ogdch_cleanup_resources(context, data_dict):
     if not dryrun and delete_filestore_files:
         filepaths = []
         # check the FileStore for artifacts of that resource
-        for id in delete_resources_ids[:100]:
+        for id in delete_resources_ids:
             directory = get_directory(id)
             filepath = get_path(id)
             filepaths.append(filepath)


### PR DESCRIPTION
With the option delete_filestore_files the cleanup_resources-command will delete all filestore-files associated to the deleted resources.