### PR TITLE
fix: interpret the format that scheduled-field is saved in

### DIFF
--- a/ckanext/ogdchcommands/cli.py
+++ b/ckanext/ogdchcommands/cli.py
@@ -366,7 +366,7 @@ def clear_stale_harvestsources(timeframe_to_keep_harvested_datasets):
 
 
 def _is_dataset_due_to_be_published(context, dataset):
-    issued_datetime = datetime.strptime(dataset.get("scheduled"), "%d.%m.%Y")
+    issued_datetime = datetime.fromisoformat(dataset.get("scheduled"))
     if issued_datetime.date() <= datetime.today().date():
         return logic.get_action("package_show")(context, {"id": dataset.get("id")})
     else:

--- a/ckanext/ogdchcommands/cli.py
+++ b/ckanext/ogdchcommands/cli.py
@@ -366,7 +366,10 @@ def clear_stale_harvestsources(timeframe_to_keep_harvested_datasets):
 
 
 def _is_dataset_due_to_be_published(context, dataset):
-    issued_datetime = datetime.fromisoformat(dataset.get("scheduled"))
+    try:
+        issued_datetime = datetime.fromisoformat(dataset.get("scheduled"))
+    except:
+        issued_datetime = datetime.strptime(dataset.get("scheduled"), "%d.%m.%Y")
     if issued_datetime.date() <= datetime.today().date():
         return logic.get_action("package_show")(context, {"id": dataset.get("id")})
     else:


### PR DESCRIPTION
The format it is saved as is: "%Y-%m-%dT%H:%M:%S"